### PR TITLE
Upgrading to Font Awesome 5.15.3

### DIFF
--- a/src/test/suite/view/DiagramWebView.test.ts
+++ b/src/test/suite/view/DiagramWebView.test.ts
@@ -235,7 +235,7 @@ suite('DiagramWebView Tests', function() {
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Mermaid Editor Preview</title>
-      <link rel="stylesheet" href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css">
       <style>
       body {
         background-color: deep-blue;
@@ -306,7 +306,7 @@ suite('DiagramWebView Tests', function() {
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Mermaid Editor Preview</title>
-      <link rel="stylesheet" href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css">
       <style>
       body {
         background-color: deep-blue;

--- a/src/view/DiagramWebView.ts
+++ b/src/view/DiagramWebView.ts
@@ -102,7 +102,7 @@ export default class DiagramWebView extends Renderer<
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Mermaid Editor Preview</title>
-      <link rel="stylesheet" href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css">
       <style>
       body {
         background-color: ${backgroundColor};


### PR DESCRIPTION
A small change but it should upgrade font awesome to 5.15.3.  The purpose is that the 5.x Font Awesome adds bunch of useful network icons.

I use VS Code, but have never created an extension myself, so unfortunately I am not sure how to test this before submitting the PR.

Thanks.