### PR TITLE
Remove the full language contribution section

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,18 +33,6 @@
   ],
   "main": "./dist/extension",
   "contributes": {
-    "languages": [
-      {
-        "id": "mermaid",
-        "extensions": [
-          ".mmd"
-        ],
-        "aliases": [
-          "Mermaid",
-          "mermaid"
-        ]
-      }
-    ],
     "configuration": [
       {
         "type": "object",


### PR DESCRIPTION
Unfortunately [last PR](https://github.com/tomoyukim/vscode-mermaid-editor/pull/59) didn't remove the syntax highlight definition fully, this will now do. 

Sorry the inconvenience, i should have tested it properly :( but whats the recommended way for doing this, never touched vs extension development..