### PR TITLE
Improve main.js typings

### DIFF
--- a/media/jsconfig.json
+++ b/media/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "allowSyntheticDefaultImports": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/media/main.d.ts
+++ b/media/main.d.ts
@@ -1,0 +1,1 @@
+declare const mermaid: typeof import('mermaid')['default'];

--- a/package.json
+++ b/package.json
@@ -279,6 +279,8 @@
   },
   "devDependencies": {
     "@types/glob": "7.1.x",
+    "@types/lodash": "4.14.x",
+    "@types/mkdirp": "1.0.x",
     "@types/mocha": "8.2.x",
     "@types/node": "10.17.x",
     "@types/vscode": "1.44.x",
@@ -302,8 +304,6 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
-    "@types/lodash": "4.14.x",
-    "@types/mkdirp": "1.0.x",
     "lodash": ">=4.17.21",
     "mermaid": "^9.4.0",
     "redux": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "@types/mocha": "8.2.x",
     "@types/node": "10.17.x",
     "@types/vscode": "1.44.x",
+    "@types/vscode-webview": "^1.57.1",
     "@typescript-eslint/eslint-plugin": "5.8.x",
     "@typescript-eslint/parser": "5.8.x",
     "copy-webpack-plugin": "^9.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "esModuleInterop": true,
     "noImplicitAny": true
   },
-  "exclude": ["dist", "node_modules", ".vscode-test"]
+  "exclude": ["dist", "node_modules", ".vscode-test", "media/main.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,11 @@
   version "10.17.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.24.tgz#c57511e3a19c4b5e9692bb2995c40a3a52167944"
 
+"@types/vscode-webview@^1.57.1":
+  version "1.57.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode-webview/-/vscode-webview-1.57.1.tgz#0bf2c9d57698b99be2bb2813272169f7f62eb714"
+  integrity sha512-ghW5SfuDmsGDS2A4xkvGsLwDRNc3Vj5rS6rPOyPm/IryZuf3wceZKxgYaUoW+k9f0f/CB7y2c1rRsdOWZWn0PQ==
+
 "@types/vscode@1.44.x":
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.44.0.tgz#62ecfe3d0e38942fce556574da54ee1013c775b7"


### PR DESCRIPTION
Might help whoever's maintaining main.js understand better what API methods are available to them. Without the typing, `mermaid` is typed as `any`.

| | Before | After |
| --- | --- | --- |
| `acquiteVsCodeApi()` | <img width="267" alt="image" src="https://user-images.githubusercontent.com/14324391/221378820-a756ffdf-3fad-4637-996f-96ea8e18920f.png"> | <img width="655" alt="image" src="https://user-images.githubusercontent.com/14324391/221378894-ced4743d-3ca4-4f37-98ca-a76d5fb180da.png"> |
| `mermaid` | <img width="427" alt="image" src="https://user-images.githubusercontent.com/14324391/221378032-4a5d5b09-52db-47a5-90eb-1f142261f49d.png"> | <img width="783" alt="image" src="https://user-images.githubusercontent.com/14324391/221378090-d96eaf84-20d8-4015-a1f4-38fec14095e8.png"> |

### Resources
- `acquireVsCodeApi()` typing with `@types/vscode-webview`: https://github.com/microsoft/vscode/issues/96221#issuecomment-849990204
- `mermaid` typing with `.d.ts` without `<reference path=...>` directive: https://stackoverflow.com/a/43659986
